### PR TITLE
feat: リザルト画面に遷移する関数の追加 #3

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
   <div>
     <div id="initialPage"></div>
     <div id="mainPage"></div>
+    <div id="resultPage"></div>
   </div>
   <script type="text/javascript" src="main.js"></script>
 </body>

--- a/main.js
+++ b/main.js
@@ -47,6 +47,7 @@ class View {
     static config = {
         initialPage : document.getElementById("initialPage"),
         mainPage: document.getElementById("mainPage"),
+        resultPage: document.getElementById("resultPage")
     }
 
 
@@ -87,6 +88,30 @@ class View {
     return container;
    }
 
+   static createResultPage(winner) {
+    let container = document.createElement("div");
+    container.classList.add("vh-100", "text-center", "d-flex", "flex-column", "justify-content-center");
+    container.innerHTML = 
+    `
+    <h1>Winner</h1>
+    <h1>${winner}</h1>
+    <div class="d-flex justify-content-center">
+        <div class="col-6">
+            <buttton id="restart" class="btn btn-primary btn-lg btn-block">
+                restart
+            </buttton>
+        </div>
+        <div class="col-6">
+            <buttton id="finish" class="btn btn-primary btn-lg btn-block">
+                finish
+            </buttton>
+        </div>
+    </div>
+    `;
+    return this.config.resultPage.append(container);
+   }
+
+
    static createInitialBoard(board) {
     let container = document.createElement("div");
     for(let i=0; i<board.length; i++){
@@ -113,6 +138,10 @@ class View {
     return container;
    }
 
+
+
+
+
 }
 
 class Controller {
@@ -128,6 +157,19 @@ class Controller {
     static moveInitialToMain(table) {
         View.config.initialPage.classList.add("d-none");
         View.config.mainPage.append(View.createMainPage(table));
+    }
+
+    static moveMainToFinish() {
+        View.config.mainPage.classList.add("d-none");
+        View.createResultPage();
+
+        let restart = View.config.resultPage.querySelectorAll("#restart")[0].addEventListener("click", function() {
+            View.config.resultPage.classList.add("d-none");
+            alert("ブラウザをリロードしてください");
+        })
+        let finish = View.config.resultPage.querySelectorAll("#finish")[0].addEventListener("click", function() {
+            View.config.resultPage.classList.add("d-none")
+        })
     }
     /*
     必要な機能


### PR DESCRIPTION
リザルト画面に移る関数を作っておきました。
ゲーム終了後に呼び出す用です。
restartとfinishと書かれたボタンがありますが、その後の処理は何か付け加えた方がよさそうです！
現状:restart⇒ブラウザのリロードをアラートで知らせる。finish⇒何もない画面へ

