### PR TITLE
feat: ターンを進めていき、先攻後攻表示を切り替える機能の追加  #16

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
   <div>
     <div id="initialPage"></div>
     <div id="mainPage"></div>
+    <div id="resultPage"></div>
   </div>
   <script type="text/javascript" src="main.js"></script>
 </body>

--- a/main.js
+++ b/main.js
@@ -57,6 +57,7 @@ class View {
     static config = {
         initialPage : document.getElementById("initialPage"),
         mainPage: document.getElementById("mainPage"),
+        resultPage: document.getElementById("resultPage")
     }
 
 
@@ -95,6 +96,29 @@ class View {
     container.querySelectorAll("#displayBoard")[0].append(View.createInitialBoard(table));
 
     return container;
+   }
+
+   static createResultPage(winner) {
+    let container = document.createElement("div");
+    container.classList.add("vh-100", "text-center", "d-flex", "flex-column", "justify-content-center");
+    container.innerHTML = 
+    `
+    <h1>Winner</h1>
+    <h1>${winner}</h1>
+    <div class="d-flex justify-content-center">
+        <div class="col-6">
+            <buttton id="restart" class="btn btn-primary btn-lg btn-block">
+                restart
+            </buttton>
+        </div>
+        <div class="col-6">
+            <buttton id="finish" class="btn btn-primary btn-lg btn-block">
+                finish
+            </buttton>
+        </div>
+    </div>
+    `;
+    return this.config.resultPage.append(container);
    }
 
    static createInitialBoard(table) {
@@ -149,7 +173,21 @@ class Controller {
         View.config.mainPage.append(View.createMainPage(table));
     }
 
+    static moveMainToFinish() {
+        View.config.mainPage.classList.add("d-none");
+        View.createResultPage();
+
+        let restart = View.config.resultPage.querySelectorAll("#restart")[0].addEventListener("click", function() {
+            View.config.resultPage.classList.add("d-none");
+            alert("ブラウザをリロードしてください");
+        })
+        let finish = View.config.resultPage.querySelectorAll("#finish")[0].addEventListener("click", function() {
+            View.config.resultPage.classList.add("d-none")
+        })
+    }
+
     static changeTurn(table) {
+        console.log(table);
         table.turn = Table.advanceTurn(table.turn);
         let player = Table.firstOrSecond(table.turn);
         View.changePlayer(player);

--- a/main.js
+++ b/main.js
@@ -5,6 +5,16 @@ class Table{
         this.board = board;
         this.turn = 1;
     }
+
+    static firstOrSecond(turn){
+        if(turn % 2 === 0) return "後攻"
+        else return "先攻"
+    }
+
+    static advanceTurn(turn) {
+        return turn + 1;
+    }
+
     /*
     プレイヤー数（二人対戦かcpuか？）を受け取る
     3×3のボードを作成し、viewに描画させる
@@ -76,33 +86,34 @@ class View {
     container.innerHTML = 
     `
     <div id="turn">
-        <h2>${table.turn}のターン</h2>
+        <h2>先攻のターン</h2>
     </div>
     <div id="displayBoard">
     </div>
     `;
 
-    container.querySelectorAll("#displayBoard")[0].append(View.createInitialBoard(table.board));
+    container.querySelectorAll("#displayBoard")[0].append(View.createInitialBoard(table));
 
     return container;
    }
 
-   static createInitialBoard(board) {
+   static createInitialBoard(table) {
     let container = document.createElement("div");
-    for(let i=0; i<board.length; i++){
+    for(let i=0; i<table.board.length; i++){
         let rowContainer = document.createElement("div");
         rowContainer.classList.add("d-flex");
-        for(let j=0; j<board[0].length; j++){
+        for(let j=0; j<table.board[0].length; j++){
             let area = document.createElement("div");
             area.classList.add("col-4", "border");
             area.innerHTML = 
             `
             <div id="${""+i+j}">
-                <p>${board[i][j]}</p>
+                <p>${table.board[i][j]}</p>
             </div>
             `;
             area.addEventListener("click", function() {
                 //Controller.InputMark(board)→モデル内のボード情報の更新と更新後のView関数を実行させる
+                Controller.changeTurn(table);
                 alert(area.innerHTML)
             })
             rowContainer.append(area);
@@ -111,6 +122,14 @@ class View {
         container.append(rowContainer);
     }
     return container;
+   }
+
+   static changePlayer(player) {
+    let turn = document.getElementById("turn");
+    turn.innerHTML =
+    `
+    <h2>${player}のターン</h2>
+    `;
    }
 
 }
@@ -128,6 +147,12 @@ class Controller {
     static moveInitialToMain(table) {
         View.config.initialPage.classList.add("d-none");
         View.config.mainPage.append(View.createMainPage(table));
+    }
+
+    static changeTurn(table) {
+        table.turn = Table.advanceTurn(table.turn);
+        let player = Table.firstOrSecond(table.turn);
+        View.changePlayer(player);
     }
     /*
     必要な機能

--- a/main.js
+++ b/main.js
@@ -11,8 +11,8 @@ class Table{
         else return "先攻"
     }
 
-    static advanceTurn(turn) {
-        return turn + 1;
+    advanceTurn() {
+        this.turn += 1;
     }
 
     /*
@@ -187,8 +187,9 @@ class Controller {
     }
 
     static changeTurn(table) {
-        table.turn = Table.advanceTurn(table.turn);
-        let player = Table.firstOrSecond(table.turn);
+        table.advanceTurn();
+        let nextTurn = table.turn;
+        let player = Table.firstOrSecond(nextTurn);
         View.changePlayer(player);
     }
 


### PR DESCRIPTION
追加点：
Controller内にテーブルオブジェクトを受け取り、ターンを進めていく関数を作成。(changeTurn)
View内に"先行"or"後攻"の文字列を受けとり、画面に描画する関数を作成。(changePlayer)
Table内に現在のターンを受け取り先攻か後攻を返す関数、ターンを進める関数を作成。(firstOrSecond、advanceTurn)


既存のコードを変更しているところがあるので、マージするかどうか相談したいです。
変更点：
View内の関数createInitialBoardの引数をboard(2次元配列)からtable(Tableオブジェクト)に変更しています。 
createInitialBoard内のクリックイベントで呼び出すchangeTurnの引数としてtableを渡すために変更しました。
ターンを保持していく必要があるので、selectGame内で作成した table をゲーム終了まで保持、更新するイメージです。
createInitialBoard内のboardを使っていた部分はtable.boardで変わらず呼び出せます。


元々createInitialBoard(table.borad)で呼び出していたところをcreateInitialBoard(table)にしただけので、大きな問題などはなさそうですが、issue#17との関係があると思うので皆さんの意見も聞きたいです。
いろいろと書いていますがコミットを見てもらえればわかるかと思います！





