### PR TITLE
feat: マス目に○×を表示する機能の追加 #17

### DIFF
--- a/main.js
+++ b/main.js
@@ -154,10 +154,10 @@ class View {
     let container = document.createElement("div");
     for(let i=0; i<table.board.length; i++){
         let rowContainer = document.createElement("div");
-        rowContainer.classList.add("d-flex");
+        rowContainer.classList.add("d-flex", "justify-content-center");
         for(let j=0; j<table.board[0].length; j++){
             let area = document.createElement("div");
-            area.classList.add("col-4", "border");
+            area.classList.add("col-12", "border", "text-center");
             area.innerHTML = 
             `
             <div id="${""+i+j}">
@@ -165,9 +165,32 @@ class View {
             </div>
             `;
             area.addEventListener("click", function() {
-                //Controller.InputMark(board)→モデル内のボード情報の更新と更新後のView関数を実行させる
-                Controller.changeTurn(table);
-                alert(area.innerHTML)
+                // 先攻、後攻の取得
+                let player = Table.firstOrSecond(table.turn);
+                // 先攻
+                if(player === "先攻" && table.board[i][j] == 0) {
+                    area.innerHTML =
+                    `
+                    <div id="${""+i+j}" class="bg-primary">
+                        <p>○</p>
+                    </div>
+                    `
+                    table.board[i][j] = 1;
+                    Controller.changeTurn(table);
+                }
+                // 後攻
+                if(player === "後攻" && table.board[i][j] == 0) {
+                    area.innerHTML =
+                    `
+                    <div id="${""+i+j}" class="bg-danger">
+                        <p>x</p>
+                    </div>
+                    `
+                    table.board[i][j] = -1;
+                    Controller.changeTurn(table);
+                }
+                // 勝敗判定の関数を実行
+                let result = Table.confirmWin();
             })
             rowContainer.append(area);
             


### PR DESCRIPTION
マス目をクリックした時にマス目に○×を表示する機能を実装しました。

area.addEventListener("click", function(){}内で現在のプレイヤー（先攻後攻）を取得後、
それぞれif文で、先攻、後攻の情報プラス、table.board[i][j] == 0であることを条件に、○または×を表示します。
クリックされたボードについては、先攻（○）であれば1、後攻（×）であれば−1になるようtable.board[i][j]の値を更新するようにしました。
○、×の写真はいいものがなかったので、背景を青、赤にしています。いいものが見つかり次第マージしたいと思います。
また、if文の中でController.changeTurn(table)を呼び出し、プレイヤー情報を更新しています。
その他、配置や表示サイズを少々変更しています。
時間がかかってしまいましたが、ご確認よろしくお願いします！


