### PR TITLE
fix;〇✕表示済みのマスをクリックするとターンのみ進むバグを修正しました。

### DIFF
--- a/main.js
+++ b/main.js
@@ -173,7 +173,6 @@ class View {
                         table.board[i][j] = 1;
                         Controller.startGame(table);
                     }
-                    // 後攻
                     if(player === "後攻") {
                         area.innerHTML =
                         `
@@ -225,10 +224,10 @@ class Controller {
 
         let restart = View.config.resultPage.querySelectorAll("#restart")[0].addEventListener("click", function() {
             View.config.resultPage.classList.add("d-none");
-            alert("ブラウザをリロードしてください");
+            location.reload();
         })
         let finish = View.config.resultPage.querySelectorAll("#finish")[0].addEventListener("click", function() {
-            View.config.resultPage.classList.add("d-none")
+            View.config.resultPage.classList.add("d-none");
         })
     }
 

--- a/main.js
+++ b/main.js
@@ -161,39 +161,30 @@ class View {
             </div>
             `;
             area.addEventListener("click", function() {
-
-                //table.board[i][j] = table.turn % 2;
-                //console.log(table.board[i]);
-                //Controller.startGame(table);
-
-                //yoppiさんのマスに〇✕を表示する部分(tableの情報とViewの更新) 
-                // 先攻、後攻の取得
-                let player = Table.firstOrSecond(table.turn);
-                // 先攻
-                if(player === "先攻" && table.board[i][j] == 0) {
-                    area.innerHTML =
-                    `
-                    <div id="${""+i+j}" class="bg-primary">
-                        <p>○</p>
-                    </div>
-                    `;
-                    table.board[i][j] = 1;
-                    //Controller.changeTurn(table); 
+                if(table.board[i][j] == 0){
+                    let player = Table.firstOrSecond(table.turn);
+                    if(player === "先攻") {
+                        area.innerHTML =
+                        `
+                        <div id="${""+i+j}" class="bg-primary">
+                            <p>○</p>
+                        </div>
+                        `;
+                        table.board[i][j] = 1;
+                        Controller.startGame(table);
+                    }
+                    // 後攻
+                    if(player === "後攻") {
+                        area.innerHTML =
+                        `
+                        <div id="${""+i+j}" class="bg-danger">
+                            <p>x</p>
+                        </div>
+                        `;
+                        table.board[i][j] = -1;
+                        Controller.startGame(table);
+                    } 
                 }
-                // 後攻
-                if(player === "後攻" && table.board[i][j] == 0) {
-                    area.innerHTML =
-                    `
-                    <div id="${""+i+j}" class="bg-danger">
-                        <p>x</p>
-                    </div>
-                    `;
-                    table.board[i][j] = -1;
-                    //Controller.changeTurn(table);
-                }
-                // 勝敗判定の関数を実行
-                //let result = table.confirmWin();
-                Controller.startGame(table);  //pimonさん作成した関数をここで呼び出し。 
             })
             rowContainer.append(area);
             


### PR DESCRIPTION
変更点1
〇✕表示済みのマスをクリックするとターンのみが進んでしまっていたので修正しました。#24
仕様：クリックされたボードの中身が0の時のみ以下の3つの操作を行うというような仕様に変更する
・〇✕表示 
・ターンを進める (Controller.startGame(table);)
・勝利条件のチェック(Controller.startGame(table);)


変更点2
結果画面のrestartボタンを押すと自動でブラウザをリロードする使用に変更しました。



Closes #24