### PR TITLE
feat: 結果画面に勝者を表示する機能の追加

### DIFF
--- a/main.js
+++ b/main.js
@@ -123,12 +123,19 @@ class View {
     return container;
    }
 
-   static createResultPage(winner) {
+   static createResultPage(table) {
     let container = document.createElement("div");
     container.classList.add("vh-100", "text-center", "d-flex", "flex-column", "justify-content-center");
+
+    let winner = "";
+    if(table.turn >= 9){
+        winner = "Drow";
+    }else{
+        winner = "Winner: " + Table.firstOrSecond(table.turn);
+    }
+
     container.innerHTML = 
     `
-    <h1>Winner</h1>
     <h1>${winner}</h1>
     <div class="d-flex justify-content-center">
         <div class="col-6">
@@ -218,9 +225,9 @@ class Controller {
         View.config.mainPage.append(View.createMainPage(table));
     }
 
-    static moveMainToFinish() {
+    static moveMainToFinish(table) {
         View.config.mainPage.classList.add("d-none");
-        View.createResultPage();
+        View.createResultPage(table);
 
         let restart = View.config.resultPage.querySelectorAll("#restart")[0].addEventListener("click", function() {
             View.config.resultPage.classList.add("d-none");
@@ -243,7 +250,7 @@ class Controller {
         if (flag) {
             Controller.changeTurn(table);
         }else{
-            this.moveMainToFinish();
+            this.moveMainToFinish(table);
         }
     }
 

--- a/main.js
+++ b/main.js
@@ -4,6 +4,7 @@ class Table{
     constructor(board){
         this.board = board;
         this.turn = 1;
+        this.isDraw = false;
     }
 
     static firstOrSecond(turn){
@@ -24,10 +25,6 @@ class Table{
     -controllerからボード上のマスクリック通知が来たら、マスの状態を更新して、viewに描画させる
      */
     confirmWin() {
-
-        //空きマスのチェック
-        if(this.turn === 9) return false;
-
         //横のチェック
         for(let i=0; i<3; i++){
             if (this.board[i][0] !== 0 && this.board[i][0] === this.board[i][1] && this.board[i][1] === this.board[i][2]){
@@ -49,6 +46,12 @@ class Table{
             }else if(this.board[1][1] === this.board[0][2] && this.board[1][1] === this.board[2][0]){
                 return false;
             }
+        }
+
+        //空きマスのチェック、9マス目で勝敗が決まらなかった場合はtable.isDrawをtrueに変更する。→結果画面の表示のため
+        if(this.turn === 9){
+            this.isDraw = true;
+            return false;
         }
 
         return true;
@@ -128,8 +131,8 @@ class View {
     container.classList.add("vh-100", "text-center", "d-flex", "flex-column", "justify-content-center");
 
     let winner = "";
-    if(table.turn >= 9){
-        winner = "Drow";
+    if(table.isDraw){
+        winner = "Draw";
     }else{
         winner = "Winner: " + Table.firstOrSecond(table.turn);
     }
@@ -246,7 +249,7 @@ class Controller {
     }
 
     static startGame(table) {
-        let flag = table.confirmWin(table);
+        let flag = table.confirmWin();
         if (flag) {
             Controller.changeTurn(table);
         }else{


### PR DESCRIPTION
結果画面に勝者を表示、引き分けの際はDrawを表示します。#26
View.createResultPage(table)のようにtableを引数として与えることで、
この関数内で Table.firstOrSecond(table.turn) のように呼び出し勝者を得て、それを表示します。

Drawの表示に関しては、Tableの変数にisDrawを作成(コンストラクタでfalseを代入)しており、
9マス埋まって終了の時isDrawをTrueに変換します。これを使ってView.createResultPage(table)内で引き分けの処理を行います。

confirmWin()内の空きマスのチェックが勝敗判定よりも先に記述してあるので、9マス目で勝敗がついたとしても引き分けであると判定されてしまうので、空きマスのチェックは勝敗判定を行った後(confirmWin()の最後)に記述してます。


Close #26