### PR TITLE
main画面の装飾とマスの0を非表示へ#27

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,11 +6,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Document</title>
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
   <div>
-    <div id="initialPage"></div>
+    <div id="initialPage" class=""></div>
     <div id="mainPage"></div>
     <div id="resultPage"></div>
   </div>

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
   <div>
-    <div id="initialPage" class=""></div>
+    <div id="initialPage"></div>
     <div id="mainPage"></div>
     <div id="resultPage"></div>
   </div>

--- a/main.js
+++ b/main.js
@@ -95,12 +95,15 @@ class View {
         container.classList.add("vh-100", "d-flex", "flex-column", "align-items-center", "justify-content-center", "text-center");
         container.innerHTML = 
         `
-        <h1>Tic-Tac-Toe</h1>
-        <div class="d-flex align-items-center justify-content-around col-8">
-            <div class="col-6">
-                <button id="vscpu" class="btn btn-primary btn-block">VS CPU</button>
+        <h1 class="">Tic-Tac-Toe</h1>
+        <br>
+        <img class="startImgß" src="https://codebrainer.azureedge.net/images/tic-tac-toe_04.png" height="350" width="350">
+        <div class="d-flex align-items-center justify-content-around">
+            <br><br><br>
+            <div class="col-7">
+                <button id="vscpu" class="btn btn-danger btn-block">VS CPU</button>
             </div>
-            <div class="col-6">
+            <div class="col-7">
                 <button id="vsfriend" class="btn btn-primary btn-block">VS Friend</button> 
             </div>
         </div>
@@ -139,6 +142,7 @@ class View {
 
     container.innerHTML = 
     `
+    <h1>Winner</h1>
     <h1>${winner}</h1>
     <div class="d-flex justify-content-center">
         <div class="col-6">
@@ -163,11 +167,11 @@ class View {
         rowContainer.classList.add("d-flex", "justify-content-center");
         for(let j=0; j<table.board[0].length; j++){
             let area = document.createElement("div");
-            area.classList.add("col-12", "border", "text-center");
+            area.classList.add("col-10", "board-border","text-center");
             area.innerHTML = 
             `
             <div id="${""+i+j}">
-                <p>${table.board[i][j]}</p>
+                <div></div>
             </div>
             `;
             area.addEventListener("click", function() {
@@ -176,8 +180,8 @@ class View {
                     if(player === "先攻") {
                         area.innerHTML =
                         `
-                        <div id="${""+i+j}" class="bg-primary">
-                            <p>○</p>
+                        <div id="${""+i+j}" class="text-primary pt-3 d-flex justify-content-center aligin-items-center">
+                            <p class="circle">○</p>
                         </div>
                         `;
                         table.board[i][j] = 1;
@@ -186,8 +190,8 @@ class View {
                     if(player === "後攻") {
                         area.innerHTML =
                         `
-                        <div id="${""+i+j}" class="bg-danger">
-                            <p>x</p>
+                        <div id="${""+i+j}" class="text-danger pt-3 d-flex justify-content-center aligin-items-center">
+                            <p class="cross">×</p>
                         </div>
                         `;
                         table.board[i][j] = -1;

--- a/styles.css
+++ b/styles.css
@@ -1,1 +1,15 @@
+.board-border{
+    border: 1px solid;
+    width: 30px;
+    height: 70px;
+}
 
+.circle{
+    font-size: 1.5rem;
+    font-weight: 900;
+}
+
+.cross{
+    font-size: 1.5rem;
+    font-weight: 900;
+}


### PR DESCRIPTION
main画面の装飾とマスの0を非表示にする修正が完了しました！
main画面は個人的にいいなと思った画像の追加と、「VS CPU」,「VS Friend」のボタンを色分けしました。
boardの0表示をなくすのと同時に○、×が表示されてもボードの枠のサイズが変化しないようにしました。
○、×については、画像ではなくそれぞれ青、赤のテキストで太字表示でもいいのではと思い修正してあります。
画像表示の方がよければ探し出すので、ご確認よろしくお願いします！